### PR TITLE
Fix PrivateName Syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ The lexical grammar is extended with an additional token:
 
 ```
 PrivateName ::
-    `#` IdentifierPart
-    PrivateName IdentifierPart
+    `#` IdentifierName
 ```
 
 Private field definitions are allowed within class bodies:


### PR DESCRIPTION
In the spec text, it is `IdentifierName`.